### PR TITLE
feat: add link to documentation on the landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -182,6 +182,14 @@ export default function Home() {
             >
               <LuPlayCircle /> Demo
             </a>
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://docs.web.start-ui.com/"
+              className="inline-flex items-center underline"
+            >
+              Documentation
+            </a>
           </div>
         </Section>
         <Section id="native">


### PR DESCRIPTION
<img width="1717" height="989" alt="image" src="https://github.com/user-attachments/assets/ae74f8a1-893d-462f-b508-3d458efde98b" />
